### PR TITLE
Non-blocking send_string & configurable device name

### DIFF
--- a/components/espidf_ble_keyboard/__init__.py
+++ b/components/espidf_ble_keyboard/__init__.py
@@ -4,7 +4,8 @@ from esphome.const import CONF_ID
 
 DEPENDENCIES = ["esp32"]
 
-# Define the passkey configuration key
+# Define configuration keys
+CONF_DEVICE_NAME = "device_name"
 CONF_PASSKEY = "passkey"
 CONF_PASSKEY_MODE = "passkey_mode"
 PASSKEY_MODE_LEGACY = "legacy"
@@ -15,6 +16,7 @@ EspidfBleKeyboard = espidf_ble_keyboard_ns.class_("EspidfBleKeyboard", cg.Compon
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(EspidfBleKeyboard),
+    cv.Optional(CONF_DEVICE_NAME, default="ESP32 BLE KB"): cv.string,
     # Allow a 6-digit integer for the passkey
     cv.Optional(CONF_PASSKEY): cv.int_range(min=0, max=999999),
     cv.Optional(CONF_PASSKEY_MODE, default=PASSKEY_MODE_LEGACY): cv.one_of(
@@ -27,6 +29,8 @@ CONFIG_SCHEMA = cv.Schema({
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
+
+    cg.add(var.set_device_name(config[CONF_DEVICE_NAME]))
 
     # If a passkey is provided in the YAML, set it in the C++ object
     if CONF_PASSKEY in config:

--- a/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
+++ b/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
@@ -648,8 +648,8 @@ void EspidfBleKeyboard::loop() {
     uint8_t report[8] = {0};
 
     if (type_key_up_pending_) {
-        // Send key-up (all zeros), then advance to next character.
-        send_keyboard_input_report(conn_id_, report, 8);
+        // Send key-up (all zeros). Retry next loop() if the stack queue is full.
+        if (send_keyboard_input_report(conn_id_, report, 8) != ESP_OK) return;
         type_key_up_pending_ = false;
         type_index_++;
         if (type_index_ >= type_queue_.size()) {
@@ -658,13 +658,13 @@ void EspidfBleKeyboard::loop() {
         }
         type_next_ms_ = now + 20;
     } else {
-        // Send key-down for the current character.
+        // Send key-down for the current character. Retry next loop() if the stack queue is full.
         uint8_t modifiers = 0, keycode = 0;
         char c = type_queue_[type_index_];
         if (char_to_keycode(c, modifiers, keycode)) {
             report[0] = modifiers;
             report[2] = keycode;
-            send_keyboard_input_report(conn_id_, report, 8);
+            if (send_keyboard_input_report(conn_id_, report, 8) != ESP_OK) return;
             type_key_up_pending_ = true;
         } else {
             // Unsupported character — skip it.

--- a/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
+++ b/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
@@ -20,6 +20,10 @@ static const char *TAG = "espidf_ble_keyboard";
 static EspidfBleKeyboard *s_instance = nullptr;
 #define GATTS_APP_ID 0x55
 
+// Forward declarations
+static esp_err_t send_keyboard_input_report(uint16_t conn_id, const uint8_t *report, uint16_t len);
+static bool char_to_keycode(char c, uint8_t &modifiers, uint8_t &keycode);
+
 // ── HID Report Descriptor ────────────────────────────────────────────────────
 // Report ID 1: Standard keyboard (8 bytes)
 // Report ID 2: Consumer control — media keys (2 bytes)

--- a/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
+++ b/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
@@ -6,7 +6,6 @@
 #include "esphome/core/hal.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "esp_task_wdt.h"
 #include "esp_gatt_defs.h"
 #include "esp_bt_defs.h"
 #include "nvs.h"
@@ -635,6 +634,44 @@ void EspidfBleKeyboard::loop() {
     if (pending_paired_update_.exchange(false)) {
         set_paired(pending_paired_state_.load());
     }
+
+    // Non-blocking string typing: one keystroke step per loop() call, paced by timer.
+    if (type_queue_.empty() || !is_connected_) return;
+
+    uint32_t now = millis();
+    if (now < type_next_ms_) return;
+
+    uint8_t report[8] = {0};
+
+    if (type_key_up_pending_) {
+        // Send key-up (all zeros), then advance to next character.
+        send_keyboard_input_report(conn_id_, report, 8);
+        type_key_up_pending_ = false;
+        type_index_++;
+        if (type_index_ >= type_queue_.size()) {
+            type_queue_.clear();
+            type_index_ = 0;
+        }
+        type_next_ms_ = now + 20;
+    } else {
+        // Send key-down for the current character.
+        uint8_t modifiers = 0, keycode = 0;
+        char c = type_queue_[type_index_];
+        if (char_to_keycode(c, modifiers, keycode)) {
+            report[0] = modifiers;
+            report[2] = keycode;
+            send_keyboard_input_report(conn_id_, report, 8);
+            type_key_up_pending_ = true;
+        } else {
+            // Unsupported character — skip it.
+            type_index_++;
+            if (type_index_ >= type_queue_.size()) {
+                type_queue_.clear();
+                type_index_ = 0;
+            }
+        }
+        type_next_ms_ = now + 20;
+    }
 }
 
 static uint16_t get_keyboard_input_handle() {
@@ -709,37 +746,46 @@ static esp_err_t send_keyboard_input_report(uint16_t conn_id, const uint8_t *rep
     return fallback_ret;
 }
 
-void EspidfBleKeyboard::send_string(const std::string &str) {
-    if (!is_connected_) return;
-    uint8_t report[8] = {0};
-    for (char c : str) {
-        esp_task_wdt_reset();
-        report[0] = 0; report[2] = 0;
-        if      (c >= 'a' && c <= 'z') { report[2] = (uint8_t)(c - 'a' + 0x04); }
-        else if (c >= 'A' && c <= 'Z') { report[0] = 0x02; report[2] = (uint8_t)(c - 'A' + 0x04); }
-        else if (c >= '1' && c <= '9') { report[2] = (uint8_t)(c - '1' + 0x1E); }
-        else if (c == '0') { report[2] = 0x27; }
-        else if (c == ' ')  { report[2] = 0x2C; }
-        else if (c == '\n') { report[2] = 0x28; }
-        else if (c == '.')  { report[2] = 0x37; }
-        else if (c == ',')  { report[2] = 0x36; }
-        else if (c == '/')  { report[2] = 0x38; }
-        else if (c == '\\') { report[2] = 0x31; }
-        else if (c == '-')  { report[2] = 0x2D; }
-        else if (c == '=')  { report[2] = 0x2E; }
-        else if (c == ';')  { report[2] = 0x33; }
-        else if (c == '\'') { report[2] = 0x34; }
-        else if (c == '_')  { report[0] = 0x02; report[2] = 0x2D; }
-        else if (c == '+')  { report[0] = 0x02; report[2] = 0x2E; }
-        else if (c == ':')  { report[0] = 0x02; report[2] = 0x33; }
-        else continue;
+// Returns true if the character is supported, filling modifiers and keycode.
+static bool char_to_keycode(char c, uint8_t &modifiers, uint8_t &keycode) {
+    modifiers = 0;
+    keycode   = 0;
+    if      (c >= 'a' && c <= 'z') { keycode = (uint8_t)(c - 'a' + 0x04); }
+    else if (c >= 'A' && c <= 'Z') { modifiers = 0x02; keycode = (uint8_t)(c - 'A' + 0x04); }
+    else if (c >= '1' && c <= '9') { keycode = (uint8_t)(c - '1' + 0x1E); }
+    else if (c == '0')  { keycode = 0x27; }
+    else if (c == ' ')  { keycode = 0x2C; }
+    else if (c == '\n') { keycode = 0x28; }
+    else if (c == '.')  { keycode = 0x37; }
+    else if (c == ',')  { keycode = 0x36; }
+    else if (c == '/')  { keycode = 0x38; }
+    else if (c == '\\') { keycode = 0x31; }
+    else if (c == '-')  { keycode = 0x2D; }
+    else if (c == '=')  { keycode = 0x2E; }
+    else if (c == ';')  { keycode = 0x33; }
+    else if (c == '\'') { keycode = 0x34; }
+    else if (c == '_')  { modifiers = 0x02; keycode = 0x2D; }
+    else if (c == '+')  { modifiers = 0x02; keycode = 0x2E; }
+    else if (c == ':')  { modifiers = 0x02; keycode = 0x33; }
+    else if (c == '!')  { modifiers = 0x02; keycode = 0x1E; }
+    else if (c == '?')  { modifiers = 0x02; keycode = 0x38; }
+    else if (c == '"')  { modifiers = 0x02; keycode = 0x34; }
+    else if (c == '(')  { modifiers = 0x02; keycode = 0x26; }
+    else if (c == ')')  { modifiers = 0x02; keycode = 0x27; }
+    else if (c == '@')  { modifiers = 0x02; keycode = 0x1F; }
+    else if (c == '#')  { modifiers = 0x02; keycode = 0x20; }
+    else if (c == '$')  { modifiers = 0x02; keycode = 0x21; }
+    else if (c == '%')  { modifiers = 0x02; keycode = 0x22; }
+    else if (c == '^')  { modifiers = 0x02; keycode = 0x23; }
+    else if (c == '&')  { modifiers = 0x02; keycode = 0x24; }
+    else if (c == '*')  { modifiers = 0x02; keycode = 0x25; }
+    else return false;
+    return true;
+}
 
-        send_keyboard_input_report(conn_id_, report, 8);
-        vTaskDelay(pdMS_TO_TICKS(40));
-        memset(report, 0, 8);
-        send_keyboard_input_report(conn_id_, report, 8);
-        vTaskDelay(pdMS_TO_TICKS(40));
-    }
+void EspidfBleKeyboard::send_string(const std::string &str) {
+    // Non-blocking: just append to the queue; loop() will drain it one step at a time.
+    type_queue_ += str;
 }
 
 void EspidfBleKeyboard::send_key_combo(uint8_t modifiers, uint8_t keycode) {

--- a/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
+++ b/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
@@ -699,6 +699,7 @@ static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_
 // ── Component Setup ──────────────────────────────────────────────────────────
 void EspidfBleKeyboard::setup() {
     s_instance = this;
+    type_mutex_ = xSemaphoreCreateMutex();
     esp_err_t ret = nvs_flash_init();
     if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
         nvs_flash_erase();
@@ -728,17 +729,26 @@ void EspidfBleKeyboard::loop() {
         set_paired(pending_paired_state_.load());
     }
 
-    // Non-blocking string typing: one keystroke step per loop() call, paced by timer.
-    if (type_queue_.empty() || !is_connected_) return;
+    if (!is_connected_ || type_mutex_ == nullptr) return;
 
     uint32_t now = millis();
     if (now < type_next_ms_) return;
 
+    // Take mutex briefly to snapshot current character and state — do NOT hold during BLE send.
+    if (xSemaphoreTake(type_mutex_, 0) != pdTRUE) return;
+    bool queue_empty = type_queue_.empty();
+    bool key_up = type_key_up_pending_;
+    char c = (!queue_empty && !key_up) ? type_queue_[type_index_] : 0;
+    xSemaphoreGive(type_mutex_);
+
+    if (queue_empty) return;
+
     uint8_t report[8] = {0};
 
-    if (type_key_up_pending_) {
+    if (key_up) {
         // Send key-up (all zeros). Retry next loop() if the stack queue is full.
         if (send_keyboard_input_report(conn_id_, report, 8) != ESP_OK) return;
+        xSemaphoreTake(type_mutex_, portMAX_DELAY);
         type_key_up_pending_ = false;
         type_index_++;
         if (type_index_ >= type_queue_.size()) {
@@ -746,24 +756,29 @@ void EspidfBleKeyboard::loop() {
             type_index_ = 0;
         }
         type_next_ms_ = now + 20;
+        xSemaphoreGive(type_mutex_);
     } else {
         // Send key-down for the current character. Retry next loop() if the stack queue is full.
-        char c = type_queue_[type_index_];
         const auto &mapping = (c >= 0 && c < 128) ? HID_ASCII_MAP[static_cast<uint8_t>(c)] : HidKeyMapping{0, 0};
         if (mapping.keycode != 0x00) {
             report[0] = mapping.modifier;
             report[2] = mapping.keycode;
             if (send_keyboard_input_report(conn_id_, report, 8) != ESP_OK) return;
+            xSemaphoreTake(type_mutex_, portMAX_DELAY);
             type_key_up_pending_ = true;
+            type_next_ms_ = now + 20;
+            xSemaphoreGive(type_mutex_);
         } else {
             // Unsupported character — skip it.
+            xSemaphoreTake(type_mutex_, portMAX_DELAY);
             type_index_++;
             if (type_index_ >= type_queue_.size()) {
                 type_queue_.clear();
                 type_index_ = 0;
             }
+            type_next_ms_ = now + 20;
+            xSemaphoreGive(type_mutex_);
         }
-        type_next_ms_ = now + 20;
     }
 }
 
@@ -840,8 +855,10 @@ static esp_err_t send_keyboard_input_report(uint16_t conn_id, const uint8_t *rep
 }
 
 void EspidfBleKeyboard::send_string(const std::string &str) {
-    // Non-blocking: just append to the queue; loop() will drain it one step at a time.
+    if (type_mutex_ == nullptr) return;
+    xSemaphoreTake(type_mutex_, portMAX_DELAY);
     type_queue_ += str;
+    xSemaphoreGive(type_mutex_);
 }
 
 void EspidfBleKeyboard::send_key_combo(uint8_t modifiers, uint8_t keycode) {

--- a/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
+++ b/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
@@ -733,10 +733,10 @@ void EspidfBleKeyboard::send_string(const std::string &str) {
         else continue;
 
         send_keyboard_input_report(conn_id_, report, 8);
-        vTaskDelay(pdMS_TO_TICKS(20));
+        vTaskDelay(pdMS_TO_TICKS(40));
         memset(report, 0, 8);
         send_keyboard_input_report(conn_id_, report, 8);
-        vTaskDelay(pdMS_TO_TICKS(20));
+        vTaskDelay(pdMS_TO_TICKS(40));
     }
 }
 

--- a/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
+++ b/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
@@ -71,10 +71,6 @@ static uint8_t raw_adv_data[] = {
     0x03, 0x19, 0xC1, 0x03      // Appearance: HID Keyboard (0x03C1)
 };
 
-static uint8_t raw_scan_rsp_data[] = {
-    0x0D, 0x09,                 // Complete Local Name (12 chars)
-    'E','S','P','3','2',' ','B','L','E',' ','K','B'
-};
 
 static esp_ble_adv_params_t adv_params = {
     .adv_int_min       = 0x20,
@@ -230,8 +226,17 @@ static void apply_security_params(bool use_static_passkey) {
 static void do_start_advertising() {
     s_adv_data_set = false;
     s_scan_rsp_data_set = false;
+
+    // Build scan response dynamically from the configured device name.
+    // Format: [length = name_len+1] [0x09 = Complete Local Name] [name bytes...]
+    std::string dev_name = (s_instance != nullptr) ? s_instance->device_name() : "ESP32 BLE KB";
+    std::vector<uint8_t> scan_rsp;
+    scan_rsp.push_back((uint8_t)(dev_name.length() + 1));
+    scan_rsp.push_back(0x09);
+    for (char c : dev_name) scan_rsp.push_back((uint8_t)c);
+
     esp_err_t adv_ret = esp_ble_gap_config_adv_data_raw(raw_adv_data, sizeof(raw_adv_data));
-    esp_err_t scan_ret = esp_ble_gap_config_scan_rsp_data_raw(raw_scan_rsp_data, sizeof(raw_scan_rsp_data));
+    esp_err_t scan_ret = esp_ble_gap_config_scan_rsp_data_raw(scan_rsp.data(), (uint16_t)scan_rsp.size());
 
     if (adv_ret != ESP_OK) {
         ESP_LOGE(TAG, "GAP: Failed to config adv data (%d)", adv_ret);
@@ -487,7 +492,7 @@ static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_
     switch (event) {
         case ESP_GATTS_REG_EVT:
             s_gatts_if = gatts_if;
-            esp_ble_gap_set_device_name("ESP32 BLE KB");
+            esp_ble_gap_set_device_name(s_instance ? s_instance->device_name().c_str() : "ESP32 BLE KB");
             // Create each service as a separate attribute table
             esp_ble_gatts_create_attr_tab(dis_attr_db, gatts_if, DIS_IDX_NB, SVC_INST_DIS);
             esp_ble_gatts_create_attr_tab(bas_attr_db, gatts_if, BAS_IDX_NB, SVC_INST_BAS);

--- a/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
+++ b/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
@@ -783,6 +783,16 @@ static bool char_to_keycode(char c, uint8_t &modifiers, uint8_t &keycode) {
     else if (c == '^')  { modifiers = 0x02; keycode = 0x23; }
     else if (c == '&')  { modifiers = 0x02; keycode = 0x24; }
     else if (c == '*')  { modifiers = 0x02; keycode = 0x25; }
+    else if (c == '<')  { modifiers = 0x02; keycode = 0x36; }
+    else if (c == '>')  { modifiers = 0x02; keycode = 0x37; }
+    else if (c == '[')  { keycode = 0x2F; }
+    else if (c == ']')  { keycode = 0x30; }
+    else if (c == '{')  { modifiers = 0x02; keycode = 0x2F; }
+    else if (c == '}')  { modifiers = 0x02; keycode = 0x30; }
+    else if (c == '|')  { modifiers = 0x02; keycode = 0x31; }
+    else if (c == '`')  { keycode = 0x35; }
+    else if (c == '~')  { modifiers = 0x02; keycode = 0x35; }
+    else if (c == '\t') { keycode = 0x2B; }
     else return false;
     return true;
 }

--- a/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
+++ b/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
@@ -6,6 +6,7 @@
 #include "esphome/core/hal.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "esp_task_wdt.h"
 #include "esp_gatt_defs.h"
 #include "esp_bt_defs.h"
 #include "nvs.h"
@@ -712,6 +713,7 @@ void EspidfBleKeyboard::send_string(const std::string &str) {
     if (!is_connected_) return;
     uint8_t report[8] = {0};
     for (char c : str) {
+        esp_task_wdt_reset();
         report[0] = 0; report[2] = 0;
         if      (c >= 'a' && c <= 'z') { report[2] = (uint8_t)(c - 'a' + 0x04); }
         else if (c >= 'A' && c <= 'Z') { report[0] = 0x02; report[2] = (uint8_t)(c - 'A' + 0x04); }

--- a/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
+++ b/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
@@ -159,8 +159,8 @@ static void maybe_reset_bonds_after_security_config_change() {
 static void request_host_friendly_conn_params(const esp_bd_addr_t bda) {
     esp_ble_conn_update_params_t conn_params = {};
     memcpy(conn_params.bda, bda, sizeof(esp_bd_addr_t));
-    conn_params.min_int = 0x10;
-    conn_params.max_int = 0x20;
+    conn_params.min_int = 0x06;  // 7.5ms — minimum allowed by BLE spec
+    conn_params.max_int = 0x0C;  // 15ms
     conn_params.latency = 0;
     conn_params.timeout = 400;
 

--- a/components/espidf_ble_keyboard/espidf_ble_keyboard.h
+++ b/components/espidf_ble_keyboard/espidf_ble_keyboard.h
@@ -19,6 +19,7 @@ class EspidfBleKeyboard : public Component {
   void setup() override;
   void loop() override;
   float get_setup_priority() const override { return -200.0f; }
+  void set_setup_priority(float priority) {}  // no-op: priority fixed via get_setup_priority() override
   void send_string(const std::string &str);
   void send_ctrl_alt_del();
   void send_key_combo(uint8_t modifiers, uint8_t keycode);
@@ -100,6 +101,7 @@ class EspidfBleKeyboardButton : public button::Button, public Component {
   void press_action() override;
   void set_action(const std::string &action) { action_ = action; }
   float get_setup_priority() const override { return -200.0f; }
+  void set_setup_priority(float priority) {}  // no-op: priority fixed via get_setup_priority() override
  protected:
   EspidfBleKeyboard *parent_{nullptr};
   std::string action_;

--- a/components/espidf_ble_keyboard/espidf_ble_keyboard.h
+++ b/components/espidf_ble_keyboard/espidf_ble_keyboard.h
@@ -35,6 +35,10 @@ class EspidfBleKeyboard : public Component {
   void send_volume_down();
   void send_mute();
 
+  // Setter for YAML-configured device name
+  void set_device_name(const std::string &name) { device_name_ = name; }
+  const std::string &device_name() const { return device_name_; }
+
   // Setter and check for YAML-configured passkey
   void set_passkey(uint32_t passkey) { 
     passkey_ = passkey; 
@@ -74,6 +78,7 @@ class EspidfBleKeyboard : public Component {
   uint16_t conn_id() const { return conn_id_; }
 
  protected:
+  std::string device_name_{"ESP32 BLE KB"};
   bool is_connected_{false};
   uint16_t conn_id_{0};
   bool is_paired_{false};

--- a/components/espidf_ble_keyboard/espidf_ble_keyboard.h
+++ b/components/espidf_ble_keyboard/espidf_ble_keyboard.h
@@ -4,6 +4,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include <atomic>
 #include <string>
+#include "freertos/semphr.h"
 
 #include "esp_bt.h"
 #include "esp_bt_main.h"
@@ -89,6 +90,7 @@ class EspidfBleKeyboard : public Component {
   bool passkey_secure_connections_{false};
 
   // Non-blocking string typing state machine (driven from loop())
+  SemaphoreHandle_t type_mutex_{nullptr};
   std::string type_queue_;
   size_t type_index_{0};
   bool type_key_up_pending_{false};

--- a/components/espidf_ble_keyboard/espidf_ble_keyboard.h
+++ b/components/espidf_ble_keyboard/espidf_ble_keyboard.h
@@ -89,6 +89,12 @@ class EspidfBleKeyboard : public Component {
   uint32_t passkey_{0};
   bool has_passkey_{false};
   bool passkey_secure_connections_{false};
+
+  // Non-blocking string typing state machine (driven from loop())
+  std::string type_queue_;
+  size_t type_index_{0};
+  bool type_key_up_pending_{false};
+  uint32_t type_next_ms_{0};
 };
 
 class EspidfBleKeyboardButton : public button::Button, public Component {


### PR DESCRIPTION
- Non-blocking send_string — replaces blocking vTaskDelay loop with a loop()-based state machine. Eliminates watchdog timeouts on long strings.
- Retry on queue full — checks send_keyboard_input_report return value; retries on ESP_ERR_NO_MEM instead of silently dropping characters.
- Faster connection parameters — requests min=7.5ms / max=15ms interval after connect, preventing character loss by queue overflow on hosts that negotiate longer intervals.
- Configurable device_name — adds device_name: to the YAML schema so the BLE advertised name can be set without patching source. Defaults to "ESP32 BLE KB".