### PR TITLE
Add keyboard LED state binary sensors (Num Lock, Caps Lock, Scroll Lock)

### DIFF
--- a/components/espidf_ble_keyboard/binary_sensor.py
+++ b/components/espidf_ble_keyboard/binary_sensor.py
@@ -6,10 +6,19 @@ from . import EspidfBleKeyboard
 DEPENDENCIES = ["espidf_ble_keyboard"]
 
 CONF_KEYBOARD_ID = "keyboard_id"
+CONF_TYPE = "type"
+
+TYPE_PAIRED = "paired"
+TYPE_NUM_LOCK = "num_lock"
+TYPE_CAPS_LOCK = "caps_lock"
+TYPE_SCROLL_LOCK = "scroll_lock"
 
 CONFIG_SCHEMA = binary_sensor.binary_sensor_schema().extend(
     {
         cv.Required(CONF_KEYBOARD_ID): cv.use_id(EspidfBleKeyboard),
+        cv.Optional(CONF_TYPE, default=TYPE_PAIRED): cv.one_of(
+            TYPE_PAIRED, TYPE_NUM_LOCK, TYPE_CAPS_LOCK, TYPE_SCROLL_LOCK, lower=True
+        ),
     }
 )
 
@@ -17,4 +26,13 @@ CONFIG_SCHEMA = binary_sensor.binary_sensor_schema().extend(
 async def to_code(config):
     var = await binary_sensor.new_binary_sensor(config)
     parent = await cg.get_variable(config[CONF_KEYBOARD_ID])
-    cg.add(parent.set_paired_binary_sensor(var))
+
+    sensor_type = config.get(CONF_TYPE, TYPE_PAIRED)
+    if sensor_type == TYPE_NUM_LOCK:
+        cg.add(parent.set_num_lock_binary_sensor(var))
+    elif sensor_type == TYPE_CAPS_LOCK:
+        cg.add(parent.set_caps_lock_binary_sensor(var))
+    elif sensor_type == TYPE_SCROLL_LOCK:
+        cg.add(parent.set_scroll_lock_binary_sensor(var))
+    else:
+        cg.add(parent.set_paired_binary_sensor(var))

--- a/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
+++ b/components/espidf_ble_keyboard/espidf_ble_keyboard.cpp
@@ -773,6 +773,7 @@ static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_
             if ((param->write.handle == s_hid_output_report_handle || param->write.handle == s_boot_kb_output_handle) &&
                 param->write.len > 0) {
                 ESP_LOGD(TAG, "GATTS: Keyboard LED report 0x%02X", param->write.value[0]);
+                s_instance->queue_led_state(param->write.value[0]);
             }
             break;
         default:
@@ -1126,9 +1127,21 @@ void EspidfBleKeyboard::setup() {
 #endif
 }
 
+void EspidfBleKeyboard::update_led_state_(uint8_t led_byte) {
+    if (num_lock_binary_sensor_ != nullptr)
+        num_lock_binary_sensor_->publish_state(led_byte & 0x01);
+    if (caps_lock_binary_sensor_ != nullptr)
+        caps_lock_binary_sensor_->publish_state(led_byte & 0x02);
+    if (scroll_lock_binary_sensor_ != nullptr)
+        scroll_lock_binary_sensor_->publish_state(led_byte & 0x04);
+}
+
 void EspidfBleKeyboard::loop() {
     if (pending_paired_update_.exchange(false)) {
         set_paired(pending_paired_state_.load());
+    }
+    if (pending_led_update_.exchange(false)) {
+        update_led_state_(pending_led_value_.load());
     }
     if (pending_rssi_nan_.exchange(false)) {
         if (rssi_sensor_ != nullptr) rssi_sensor_->publish_state(NAN);

--- a/components/espidf_ble_keyboard/espidf_ble_keyboard.h
+++ b/components/espidf_ble_keyboard/espidf_ble_keyboard.h
@@ -158,6 +158,14 @@ class EspidfBleKeyboard : public Component {
     pending_paired_update_.store(true);
   }
 
+  void set_num_lock_binary_sensor(binary_sensor::BinarySensor *sensor) { num_lock_binary_sensor_ = sensor; }
+  void set_caps_lock_binary_sensor(binary_sensor::BinarySensor *sensor) { caps_lock_binary_sensor_ = sensor; }
+  void set_scroll_lock_binary_sensor(binary_sensor::BinarySensor *sensor) { scroll_lock_binary_sensor_ = sensor; }
+  void queue_led_state(uint8_t led_byte) {
+    pending_led_value_.store(led_byte);
+    pending_led_update_.store(true);
+  }
+
   void set_connected(bool connected, uint16_t conn_id) {
     is_connected_ = connected;
     conn_id_ = conn_id;
@@ -235,6 +243,11 @@ class EspidfBleKeyboard : public Component {
   std::atomic<bool> pending_paired_update_{false};
   std::atomic<bool> pending_paired_state_{false};
   binary_sensor::BinarySensor *paired_binary_sensor_{nullptr};
+  std::atomic<bool> pending_led_update_{false};
+  std::atomic<uint8_t> pending_led_value_{0};
+  binary_sensor::BinarySensor *num_lock_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *caps_lock_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *scroll_lock_binary_sensor_{nullptr};
   uint32_t passkey_{0};
   bool has_passkey_{false};
   bool passkey_secure_connections_{false};
@@ -277,6 +290,7 @@ class EspidfBleKeyboard : public Component {
   std::string yaml_layout_id_{"us"};
   void load_layout_();
   void save_layout_(const std::string &id);
+  void update_led_state_(uint8_t led_byte);
 
   // Non-blocking string typing state machine (driven from loop())
   // Keystrokes are pre-resolved (UTF-8 decoded + layout-mapped) at enqueue time,


### PR DESCRIPTION
Exposes the HID keyboard LED output report (which the component already receives from the host but previously only logged) as ESPHome binary sensors.

The motivation for this came from a personal project where syncing the host's LED state with a Home Assistant entity was needed.

**Usage**
```yaml
binary_sensor:
  - platform: espidf_ble_keyboard
    keyboard_id: ble_keyboard
    name: 'Scroll Lock'
    type: scroll_lock
```

All three LED sensors (`num_lock`, `caps_lock`, `scroll_lock`) follow the standard HID LED report byte format (bits 0-2). Existing configurations with no `type` key are unaffected.